### PR TITLE
Automatically try to trigger the ESR link

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,14 @@ export class WalletPluginAnchor extends AbstractWalletPlugin {
         // Create the identity request to be presented to the user
         const {callback, request, sameDeviceRequest, requestKey, privateKey} =
             await createIdentityRequest(context, this.buoyUrl)
+
+        // Attempt to trigger the same device request immediately
+        try {
+            window.location.href = sameDeviceRequest.encode(true, false, 'esr:')
+        } catch (e) {
+            console.log('No default handler for the esr protocol was triggered automatically.')
+        }
+
         // Tell Wharf we need to prompt the user with a QR code and a button
         const promptResponse = context.ui?.prompt({
             title: t('login.title', {default: 'Connect with Anchor'}),


### PR DESCRIPTION
This will automatically attempt to trigger the ESR link as soon as the Anchor plugin shows the modal window.

I've tested this in Chrome, Brave, Firefox, and Safari. It works everywhere, except in Safari (Desktop) it throws an error to the user if they do not have Anchor installed. I'm not sure how to prevent that.